### PR TITLE
[Feature] Automatic deployment on new tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,11 @@ stages:
 - name: test
   if: (type = pull_request OR type = push) AND branch = master
 
+deploy:
+  provider: script
+  script: bundle exec fastlane deploy_pod
+  on:
+    branch: master
+    tags: true
+
 after_script: Scripts/telegram_notification.sh

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -3,6 +3,19 @@ default_platform(:ios)
 ####################################################################################################
 ####################################################################################################
 
+###################
+# Deployment lane #
+###################
+
+desc "Deploys the podspec file to Trunk"
+lane :deploy_pod do
+	pod_push(
+		path: "MathExpression.podspec",
+		verbose: false,
+		swift_version: "5.0"
+	)
+end
+
 ##############
 # Test lanes #
 ##############

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -15,6 +15,11 @@ Install _fastlane_ using
 or alternatively using `brew cask install fastlane`
 
 # Available Actions
+### deploy_pod
+```
+fastlane deploy_pod
+```
+Deploys the podspec file to Trunk
 ### build_framework
 ```
 fastlane build_framework


### PR DESCRIPTION
We add a lane and a deploy job in Travis CI to automatically deploy the `*.podspec` file to Trunk whenever we create a new release (we push a new tag to the repository).